### PR TITLE
replace text on the AccountButtonComponent with static text

### DIFF
--- a/DMStorefront/Client/Shared/AccountButtonComponent.razor
+++ b/DMStorefront/Client/Shared/AccountButtonComponent.razor
@@ -2,12 +2,11 @@
 
 
 <button class=@Class @onclick="NavigateToAccount">
-	 @Username
+	 Account Settings
 </button>
 
 
 @code {
-	[Parameter] public string Username { get; set; } = "";
 	[Parameter] public string Class { get; set; } = "";
 
 	public void NavigateToAccount()

--- a/DMStorefront/Client/Shared/NavMenu.razor
+++ b/DMStorefront/Client/Shared/NavMenu.razor
@@ -25,7 +25,7 @@
 						</a>
 					</li>
 					<li class="ms-auto">
-						<AccountButtonComponent Class="btn btn-link" Username=@Username />
+						<AccountButtonComponent Class="btn btn-link" />
 					</li>
 					<li class="py-2 btn-link">|</li>
 
@@ -41,13 +41,6 @@
 
 @code {
 	bool collapseNavMenu = true;
-	string Username { get; set; } = "";
-
-	protected override async Task OnInitializedAsync()
-	{
-		AuthenticationState authState = await authStateProvider.GetAuthenticationStateAsync();
-		Username = authState.User.Identity.Name;
-	}
 
 	string NavMenuCssClass => collapseNavMenu ? "collapse" : null;
 


### PR DESCRIPTION
I think we're better off just using "Account Settings" next ot the logout button as the text instead of the username until we decide to add centralized state management like Fluxor or something. Also kind of looks better